### PR TITLE
Adding Julia kernel information

### DIFF
--- a/ox-ipynb.el
+++ b/ox-ipynb.el
@@ -54,7 +54,10 @@
                                                          (name . "python3"))))
                                (R . (kernelspec . ((display_name . "R")
                                                    (language . "R")
-                                                   (name . "ir")))))
+                                                   (name . "ir"))))
+                               (julia . (kernelspec . ((display_name . "Julia 0.6.0")
+                                           (language . "julia")
+                                           (name . "julia-0.6")))))
   "Kernelspec metadata for different kernels.")
 
 
@@ -72,7 +75,13 @@
                            (mimetype . "text/x-r-source")
                            (name . "R")
                            (pygments_lexer . "r")
-                           (version . "3.3.2")))))
+                           (version . "3.3.2"))))
+    (julia . (language_info . ((codemirror_mode . "julia")
+                               (file_extension . ".jl")
+                               (mimetype . "text/x-julia")
+                               (name . "julia")
+                               (pygments_lexer . "julia")
+                               (version . "0.6.0")))))
   "These get injected into notebook metadata.
 They are reverse-engineered from existing notebooks.")
 


### PR DESCRIPTION
This adds support for the most recent version of Julia.

- Adds the Julia kernel for Julia-0.6.0
- Exports `.org` files with `#+BEGIN_SRC julia` to `.ipynb` with Julia kernels
- Kernel name is compatible with `jupyter nbexport` to evaluate notebook and export to other formats.