### PR TITLE
Fix warning with higher org version than 9.2.*

### DIFF
--- a/ox-ipynb.el
+++ b/ox-ipynb.el
@@ -55,7 +55,7 @@
 (require 's)
 (require 'json)
 
-(unless (string-match "^9\\.[2-9]\\.*" (org-version))
+(unless (string-match "^9\\.[2-9][\\.0-9]*" (org-version))
   (warn "org 9.2+ is required for `ox-ipynb'. Earlier versions do not currently work."))
 
 (defcustom ox-ipynb-preprocess-hook '()

--- a/ox-ipynb.el
+++ b/ox-ipynb.el
@@ -55,7 +55,7 @@
 (require 's)
 (require 'json)
 
-(unless  (string-match "^9\\.2\\." (org-version))
+(unless (string-match "^9\\.[2-9]\\.*" (org-version))
   (warn "org 9.2+ is required for `ox-ipynb'. Earlier versions do not currently work."))
 
 (defcustom ox-ipynb-preprocess-hook '()


### PR DESCRIPTION
This commit fixes issue that the package warns with 9.3 version of
org.
Also, now the patch version is regarded as optional.