### PR TITLE
Add call to json-pretty-print

### DIFF
--- a/ox-ipynb.el
+++ b/ox-ipynb.el
@@ -753,7 +753,8 @@ else is exported as a markdown cell. The output is in *ox-ipynb*."
 	 (ipynb (ox-ipynb-notebook-filename)))
      (with-current-buffer (get-buffer-create "*ox-ipynb*")
        (erase-buffer)
-       (insert (json-encode data)))
+       (insert (json-encode data))
+       (json-pretty-print-buffer))
 
      (switch-to-buffer "*ox-ipynb*")
      (setq-local export-file-name ipynb)


### PR DESCRIPTION
Add call to `json-pretty-print-buffer` to guarantee well-formated json output. This:
1. Prevents Emacs from hanging when showing the raw .ipynb;
2. Enables reasonable diffs for files under VC.