### PR TITLE
Fix warning about org version 10

### DIFF
--- a/ox-ipynb.el
+++ b/ox-ipynb.el
@@ -82,7 +82,7 @@
 (require 'ox-org)
 (require 'json)
 
-(unless (string-match "^9\\.[2-9][\\.0-9]*" (org-version))
+(unless (version-list-<= (version-to-list "9.2") (version-to-list (org-version)))
   (warn "org 9.2+ is required for `ox-ipynb'. Earlier versions do not currently work."))
 
 ;; Helper functions to replace s.el functionality


### PR DESCRIPTION
I'm using org version 10.0-pre, which triggers a warning about the wrong org mode version. This is because the regexp only looks for strings beginning with 9. I've changed the check to use version-list comparison instead.